### PR TITLE
feat(cli): Implement `stat` subcommand

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,10 +97,10 @@ _目标：构建一个健壮的、无依赖的数据收集引擎。_
   - [x] In `pipa_collector`, create a module to parse `/proc/stat` for CPU utilization. | 在 `pipa_collector` 中创建一个模块来解析 `/proc/stat` 以获取 CPU 使用率。
   - [x] In `pipa_collector`, create a module to parse `/proc/meminfo` for memory stats. | 在 `pipa_collector` 中创建一个模块来解析 `/proc/meminfo` 以获取内存统计信息。
   - [x] In `pipa_cli`, create a `monitor` subcommand that periodically calls the `system_stats` functions and prints live system info, verifying the collector's functionality. | 在 `pipa_cli` 中创建一个 `monitor` 子命令，定期调用 `system_stats` 函数并打印实时系统信息，验证收集器的功能。
-- [ ] **Task 1.3: Implement `perf_events` Counting Mode (the `perf stat` replacement)** | **任务 1.3：实现 `perf_events` 计数模式（`perf stat` 的替代品）**:
-  - [ ] Integrate the `perf-event` crate into `pipa_collector`. | 将 `perf-event` crate 集成到 `pipa_collector` 中。
-  - [ ] Implement a function to create and manage a group of performance counters for a given process (`pid`) or system-wide (`-1`). | 实现一个函数来为给定进程（`pid`）或系统级（`-1`）创建和管理一组性能计数器。
-  - [ ] In `pipa_cli`, create a `stat` subcommand (`pipa-rs stat -- <command>`) that launches a command, collects total `cycles` and `instructions`, and prints the results upon completion. | 在 `pipa_cli` 中创建一个 `stat` 子命令（`pipa-rs stat -- <command>`），启动一个命令，收集总的 `cycles` 和 `instructions`，并在完成时打印结果。
+- [x] **Task 1.3: Implement `perf_events` Counting Mode (the `perf stat` replacement)** | **任务 1.3：实现 `perf_events` 计数模式（`perf stat` 的替代品）**:
+  - [ ] ~~Integrate the `perf-event` crate into `pipa_collector`. | 将 `perf-event` crate 集成到 `pipa_collector` 中。~~(Deprecated, use raw syscalls instead)
+  - [x] Implement a function to create and manage a group of performance counters for a given process (`pid`) or system-wide (`-1`). | 实现一个函数来为给定进程（`pid`）或系统级（`-1`）创建和管理一组性能计数器。
+  - [x] In `pipa_cli`, create a `stat` subcommand (`pipa-rs stat -- <command>`) that launches a command, collects total `cycles` and `instructions`, and prints the results upon completion. | 在 `pipa_cli` 中创建一个 `stat` 子命令（`pipa-rs stat -- <command>`），启动一个命令，收集总的 `cycles` 和 `instructions`，并在完成时打印结果。
 - [ ] **Task 1.4: Implement `perf_events` Sampling Mode (the `perf record` foundation)** | **任务 1.4：实现 `perf_events` 采样模式（`perf record` 的基础）**:
   - [ ] In `pipa_collector`, configure `perf_event` for sampling with a ring buffer (`mmap`). | 在 `pipa_collector` 中配置 `perf_event` 以使用环形缓冲区（`mmap`）进行采样。
   - [ ] Implement the logic to read raw `PERF_RECORD_SAMPLE` events from the ring buffer. | 实现从环形缓冲区读取原始 `PERF_RECORD_SAMPLE` 事件的逻辑。

--- a/crates/pipa_cli/Cargo.toml
+++ b/crates/pipa_cli/Cargo.toml
@@ -21,5 +21,9 @@ bytemuck = "*"
 perf-event-open-sys = "*"
 
 
+[dev-dependencies]
+assert_cmd = "*"
+predicates = "*"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/pipa_cli/Cargo.toml
+++ b/crates/pipa_cli/Cargo.toml
@@ -15,6 +15,11 @@ clap = { version = "4.5", features = ["derive"] }
 # 优雅的应用程序级错误处理
 anyhow = "1.0"
 crossterm = "*"
+# Provides raw FFI bindings to core C libraries, needed for calling `ioctl(fd, ...)`.
+libc = "*"
+bytemuck = "*"
+perf-event-open-sys = "*"
+
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/pipa_cli/src/main.rs
+++ b/crates/pipa_cli/src/main.rs
@@ -48,6 +48,14 @@ enum Commands {
         #[arg(short, long, default_value_t = 1)]
         interval: u64,
     },
+    /// Execute a command and collect performance counter statistics.
+    /// 执行一个命令并收集性能计数器统计信息。
+    Stat {
+        /// The command to execute and profile.
+        /// 需要执行和分析的命令。
+        #[arg(required = true, last = true)]
+        command: Vec<String>,
+    },
 }
 
 /// Helper function to set up the terminal for TUI mode.
@@ -101,6 +109,28 @@ fn run_monitor(interval: u64) -> Result<()> {
     }
 
     restore_terminal(&mut f)?;
+    Ok(())
+}
+
+/// Main application logic for the stat subcommand.
+/// `stat` 子命令的主应用逻辑。
+#[cfg(not(tarpaulin_include))]
+fn run_stat(command: &[String]) -> Result<()> {
+    if command.is_empty() {
+        // This case should be prevented by clap's `required = true`, but we handle it for robustness.
+        // 这种情况应该被 clap 的 `required = true` 阻止，但为了健壮性我们还是处理一下。
+        anyhow::bail!("No command provided to `stat`.");
+    }
+
+    println!("Executing command: {:?}", command);
+    // TODO:
+    // 1. Call `pipa_collector::raw_perf_events::create_event_group`.
+    // 2. Use `std::process::Command` to set up the child process.
+    // 3. Enable the event group via `ioctl` right before spawning the child.
+    // 4. Spawn the child and wait for it to complete.
+    // 5. Read the counter values from the group leader file descriptor.
+    // 6. Print the results.
+
     Ok(())
 }
 
@@ -190,6 +220,9 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::Monitor { interval } => {
             run_monitor(interval)?;
+        }
+        Commands::Stat { command } => {
+            run_stat(&command)?;
         }
     }
     Ok(())

--- a/crates/pipa_cli/src/main.rs
+++ b/crates/pipa_cli/src/main.rs
@@ -178,7 +178,7 @@ fn run_stat(command: &[String]) -> Result<()> {
     // };
     const NUM_EVENTS: usize = 2;
     // 缓冲区大小：nr (1) + time_enabled (1) + time_running (1) + values (NUM_EVENTS)
-    const BUF_SIZE: usize = 3 + NUM_EVENTS;
+    const BUF_SIZE: usize = 3 + NUM_EVENTS * 2;
     let mut buf = [0u64; BUF_SIZE];
 
     // 为了安全地读取，我们将原始 fd 包装成一个 File，但之后必须 `mem::forget` 它，
@@ -194,7 +194,7 @@ fn run_stat(command: &[String]) -> Result<()> {
     }
 
     let cycles = buf[3];
-    let instructions = buf[4];
+    let instructions = buf[5];
     let cpi = if instructions > 0 { cycles as f64 / instructions as f64 } else { 0.0 };
 
     println!("\n--- Performance counters for `{:?}` ---\n", command);

--- a/crates/pipa_cli/src/main.rs
+++ b/crates/pipa_cli/src/main.rs
@@ -24,7 +24,15 @@ use crossterm::{
     execute, queue, style,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
+use pipa_collector::raw_perf_events::{self, PerfEvent};
 use pipa_collector::system_stats::{CpuStats, MemoryStats};
+use std::fs::File;
+use std::io;
+use std::io::Read;
+use std::mem;
+use std::os::unix::io::FromRawFd;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
 use std::{
     io::{Stdout, Write, stdout},
     time::Duration,
@@ -122,14 +130,78 @@ fn run_stat(command: &[String]) -> Result<()> {
         anyhow::bail!("No command provided to `stat`.");
     }
 
-    println!("Executing command: {:?}", command);
-    // TODO:
-    // 1. Call `pipa_collector::raw_perf_events::create_event_group`.
-    // 2. Use `std::process::Command` to set up the child process.
-    // 3. Enable the event group via `ioctl` right before spawning the child.
-    // 4. Spawn the child and wait for it to complete.
-    // 5. Read the counter values from the group leader file descriptor.
-    // 6. Print the results.
+    // 1. 定义我们想要监控的事件。
+    let events = [PerfEvent::Cycles, PerfEvent::Instructions];
+    let group = raw_perf_events::create_event_group(&events)?;
+    let leader_fd = group.leader_fd();
+
+    let program = &command[0];
+    let args = &command[1..];
+
+    // 2. 设置子进程命令。
+    let mut cmd = Command::new(program);
+    cmd.args(args);
+
+    // 3. 使用 `pre_exec` 在子进程 `exec` 之前启用计数器。
+    // 这是关键一步：`pre_exec` 允许我们在 `fork` 之后、`exec` 之前运行闭包。
+    // 这确保了只有即将执行的目标程序才会被计数。
+    unsafe {
+        cmd.pre_exec(move || {
+            // 在子进程中,我们通过 ioctl 启用整个事件组。
+            let ret = libc::ioctl(
+                leader_fd,
+                perf_event_open_sys::bindings::ENABLE as libc::c_ulong,
+                perf_event_open_sys::bindings::PERF_IOC_FLAG_GROUP,
+            );
+            if ret < 0 {
+                // 如果 ioctl 失败,返回一个错误,这将阻止子进程启动。
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    } // 4. 执行命令并等待其完成。
+    let status = cmd
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to execute command `{}`: {}", program, e))?;
+
+    if !status.success() {
+        eprintln!("Warning: Command exited with non-zero status: {}", status);
+    }
+
+    // 5. 从组长文件描述符中读取计数器结果。
+    // `perf_event` 的 `read` 格式是：
+    // struct {
+    //   u64 nr;            /* Number of events in the group */
+    //   u64 time_enabled;  /* Time the group was enabled */
+    //   u64 time_running;  /* Time the group was running */
+    //   u64 values[nr];    /* The counter values */
+    // };
+    const NUM_EVENTS: usize = 2;
+    // 缓冲区大小：nr (1) + time_enabled (1) + time_running (1) + values (NUM_EVENTS)
+    const BUF_SIZE: usize = 3 + NUM_EVENTS;
+    let mut buf = [0u64; BUF_SIZE];
+
+    // 为了安全地读取，我们将原始 fd 包装成一个 File，但之后必须 `mem::forget` 它，
+    // 否则 File 的 Drop 实现会关闭 fd，导致我们自己的 EventGroup 在 Drop 时二次关闭。
+    let mut file = unsafe { File::from_raw_fd(leader_fd) };
+    file.read_exact(bytemuck::bytes_of_mut(&mut buf))?;
+    mem::forget(file);
+
+    // 6. 解析并打印结果。
+    let nr = buf[0];
+    if nr != NUM_EVENTS as u64 {
+        anyhow::bail!("Unexpected number of events read. Expected {}, got {}.", NUM_EVENTS, nr);
+    }
+
+    let cycles = buf[3];
+    let instructions = buf[4];
+    let cpi = if instructions > 0 { cycles as f64 / instructions as f64 } else { 0.0 };
+
+    println!("\n--- Performance counters for `{:?}` ---\n", command);
+    println!("{:<20}: {}", "Cycles", cycles);
+    println!("{:<20}: {}", "Instructions", instructions);
+    println!("{:<20}: {:.2}", "CPI", cpi);
+    println!("\n------------------------------------------\n");
 
     Ok(())
 }

--- a/crates/pipa_cli/tests/stat.rs
+++ b/crates/pipa_cli/tests/stat.rs
@@ -1,0 +1,52 @@
+// Copyright 2025 cagedbird043
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn test_stat_runs_successfully_on_true() {
+    let mut cmd = Command::cargo_bin("pipa_rs").unwrap();
+    cmd.arg("stat")
+        .arg("--")
+        .arg("true") // `true` is a minimal command that does nothing and exits successfully.
+        .assert()
+        .success() // Chained method call
+        .stdout(
+            predicate::str::contains("Cycles")
+                .and(predicate::str::contains("Instructions"))
+                .and(predicate::str::contains("CPI")),
+        );
+}
+
+#[test]
+fn test_stat_reports_error_for_nonexistent_command() {
+    let mut cmd = Command::cargo_bin("pipa_rs").unwrap();
+    cmd.arg("stat")
+        .arg("--")
+        .arg("this_command_does_not_exist_12345")
+        .assert()
+        .failure() // Chained method call
+        .stderr(predicate::str::contains("Failed to execute command"));
+}
+
+#[test]
+fn test_stat_reports_error_if_no_command_is_given() {
+    let mut cmd = Command::cargo_bin("pipa_rs").unwrap();
+    cmd.arg("stat")
+        .assert()
+        .failure()
+        // Corrected the usage string to include `--` as produced by clap.
+        .stderr(predicate::str::contains("Usage: pipa_rs stat -- <COMMAND>..."));
+}

--- a/crates/pipa_collector/Cargo.toml
+++ b/crates/pipa_collector/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 # Provides raw, unsafe bindings to the perf_event_open syscall.
 # This is necessary for creating inheritable counter groups for child processes.
 perf-event-open-sys = "*"
+libc = "*"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/pipa_collector/Cargo.toml
+++ b/crates/pipa_collector/Cargo.toml
@@ -15,7 +15,9 @@ perf-event-open-sys = "*"
 libc = "*"
 
 [dev-dependencies]
-tempfile = "3.10"
+tempfile = "*"
+assert_cmd = "*"
+predicates = "*"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/pipa_collector/Cargo.toml
+++ b/crates/pipa_collector/Cargo.toml
@@ -9,6 +9,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+# Provides raw, unsafe bindings to the perf_event_open syscall.
+# This is necessary for creating inheritable counter groups for child processes.
+perf-event-open-sys = "*"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/pipa_collector/src/lib.rs
+++ b/crates/pipa_collector/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod raw_perf_events;
 pub mod system_stats;

--- a/crates/pipa_collector/src/raw_perf_events.rs
+++ b/crates/pipa_collector/src/raw_perf_events.rs
@@ -12,16 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module provides a low-level, unsafe interface to the `perf_event_open` syscall.
-//! It is designed to be the single point of contact with raw `perf_event_open` calls,
-//! isolating all `unsafe` logic related to this functionality. The primary motivation
-//! for using this raw interface is to gain access to features not exposed by safe
-//! high-level libraries, such as creating inheritable performance counter groups
-//! for monitoring child processes.
-//!
-//! 本模块提供了对 `perf_event_open` 系统调用的底层、非安全接口。
-//! 它被设计为与原始 `perf_event_open` 调用的唯一接触点，隔离了所有与此功能相关的 `unsafe` 逻辑。
-//! 使用此原始接口的主要动机是访问安全的高级库未暴露的功能，例如为监控子进程创建可继承的性能计数器组。
+//! This module provides a low-level interface to the `perf_event_open` syscall,
+//! precisely mimicking the behavior of the `perf stat` command.
 
 use crate::system_stats::PipaCollectorError;
 use perf_event_open_sys as sys;
@@ -29,20 +21,13 @@ use std::io;
 use std::os::unix::io::RawFd;
 
 /// Represents a specific hardware performance event that can be monitored.
-///
-/// 代表一个可以被监控的特定硬件性能事件。
 #[derive(Debug, Clone, Copy)]
 pub enum PerfEvent {
-    /// Counts the number of CPU cycles. / 统计 CPU 周期数。
     Cycles,
-    /// Counts the number of instructions executed. / 统计执行的指令数。
     Instructions,
 }
 
 impl PerfEvent {
-    /// Converts the enum variant into the raw `type` and `config` values required by `perf_event_attr`.
-    ///
-    /// 将枚举变体转换为 `perf_event_attr` 所需的原始 `type` 和 `config` 值。
     fn to_config(self) -> (u32, u64) {
         match self {
             Self::Cycles => {
@@ -56,104 +41,55 @@ impl PerfEvent {
     }
 }
 
-/// A handle to a group of performance counters, ensuring they are closed on drop.
-/// This struct manages the lifecycle of the file descriptors returned by `perf_event_open`.
-///
-/// 性能计数器组的句柄，确保在销毁时关闭它们。
-/// 此结构体管理 `perf_event_open` 返回的文件描述符的生命周期。
+/// A handle to a single performance counter, ensuring it is closed on drop.
 #[derive(Debug)]
-pub struct EventGroup {
-    fds: Vec<RawFd>,
+pub struct Counter {
+    fd: RawFd,
 }
 
-impl EventGroup {
-    /// Returns the file descriptor of the group leader.
-    /// This is the primary FD used for group-wide operations like `ioctl`.
-    ///
-    /// 返回组长的文件描述符。
-    /// 这是用于组范围操作（如 `ioctl`）的主要文件描述符。
-    pub fn leader_fd(&self) -> RawFd {
-        // The first FD in our list is always the leader.
-        // The constructor ensures the list is never empty.
-        self.fds[0]
+impl Counter {
+    pub fn fd(&self) -> RawFd {
+        self.fd
     }
 }
 
-impl Drop for EventGroup {
-    /// Closes all file descriptors associated with this event group.
-    ///
-    /// 关闭与此事件组关联的所有文件描述符。
+impl Drop for Counter {
     fn drop(&mut self) {
-        for &fd in &self.fds {
-            // This is an unsafe call to a C function, but it's safe in this context
-            // as we own the file descriptors and they are valid until `drop` is called.
-            // 这是一个对 C 函数的非安全调用，但在这种上下文中是安全的，
-            // 因为我们拥有文件描述符，并且它们在 `drop` 被调用前都是有效的。
-            unsafe {
-                libc::close(fd);
-            }
+        unsafe {
+            libc::close(self.fd);
         }
     }
 }
 
-/// Creates a group of performance counters that can be inherited by child processes.
-/// The group is created in a disabled state.
-///
-/// 创建一个可由子进程继承的性能计数器组。
-/// 该组在创建时处于禁用状态。
-///
-/// # Arguments
-/// * `events`: A slice of `PerfEvent`s to monitor. The first event becomes the group leader.
-///
-/// # Returns
-/// An `EventGroup` handle on success, which manages the file descriptors.
-pub fn create_event_group(events: &[PerfEvent]) -> Result<EventGroup, PipaCollectorError> {
-    if events.is_empty() {
-        return Err(PipaCollectorError::InvalidFormat(
-            "Cannot create an event group with no events.".to_string(),
-        ));
+/// Creates a single, inheritable performance counter for a command to be executed.
+/// This function precisely replicates the parameters used by `perf stat`.
+pub fn create_counter_for_command(event: PerfEvent) -> Result<Counter, PipaCollectorError> {
+    let mut attrs = sys::bindings::perf_event_attr {
+        size: std::mem::size_of::<sys::bindings::perf_event_attr>() as u32,
+        ..Default::default()
+    };
+    let (type_, config) = event.to_config();
+    attrs.type_ = type_;
+    attrs.config = config;
+
+    // --- Settings copied exactly from `perf stat` strace ---
+    attrs.set_disabled(1); // Start disabled.
+    attrs.set_inherit(1); // Inherit to child processes.
+    attrs.set_enable_on_exec(1); // Kernel will auto-enable on `execve`.
+
+    // pid = 0: Monitor the current process. With inherit=1, this targets children.
+    // cpu = -1: Monitor on any CPU the process runs on.
+    // group_fd = -1: This is a standalone counter, not part of a group.
+    // flags = 0: No special flags needed for this basic case.
+    let fd = unsafe { sys::perf_event_open(&mut attrs, 0, -1, -1, 0) };
+
+    if fd < 0 {
+        let last_error = io::Error::last_os_error();
+        return Err(PipaCollectorError::Io(io::Error::new(
+            last_error.kind(),
+            format!("perf_event_open failed for event {:?}: {}", event, last_error),
+        )));
     }
 
-    let mut fds = Vec::with_capacity(events.len());
-    let mut leader_fd: RawFd = -1;
-
-    for (i, event) in events.iter().enumerate() {
-        let (type_, config) = event.to_config();
-
-        let mut attrs = sys::bindings::perf_event_attr {
-            type_,
-            config,
-            size: std::mem::size_of::<sys::bindings::perf_event_attr>() as u32,
-            ..Default::default()
-        };
-
-        // --- Critical Settings for Child Process Monitoring ---
-        if i == 0 {
-            attrs.set_disabled(1);
-            attrs.set_inherit(1);
-            attrs.read_format =
-                (sys::bindings::PERF_FORMAT_GROUP | sys::bindings::PERF_FORMAT_ID) as u64;
-        }
-
-        // The syscall is unsafe because it's a raw FFI call.
-        // We must ensure the arguments are valid.
-        // `pid = 0`: Monitor the current process's children (when they exec).
-        // `cpu = -1`: Monitor on all CPUs.
-        // `group_fd`: The FD of the group leader, or -1 if this *is* the leader.
-        // `flags = 0`: No special flags needed.
-        let fd = unsafe { sys::perf_event_open(&mut attrs, 0, -1, leader_fd, 0) };
-
-        if fd < 0 {
-            // On error, `perf_event_open` returns a negative value.
-            // We capture the OS error (from `errno`) and return it.
-            return Err(PipaCollectorError::Io(io::Error::last_os_error()));
-        }
-
-        if i == 0 {
-            leader_fd = fd;
-        }
-        fds.push(fd);
-    }
-
-    Ok(EventGroup { fds })
+    Ok(Counter { fd })
 }

--- a/crates/pipa_collector/src/raw_perf_events.rs
+++ b/crates/pipa_collector/src/raw_perf_events.rs
@@ -23,4 +23,135 @@
 //! 它被设计为与原始 `perf_event_open` 调用的唯一接触点，隔离了所有与此功能相关的 `unsafe` 逻辑。
 //! 使用此原始接口的主要动机是访问安全的高级库未暴露的功能，例如为监控子进程创建可继承的性能计数器组。
 
-// TODO: Implement wrapper functions around the syscall.
+use crate::system_stats::PipaCollectorError;
+use perf_event_open_sys as sys;
+use std::io;
+use std::os::unix::io::RawFd;
+
+/// Represents a specific hardware performance event that can be monitored.
+///
+/// 代表一个可以被监控的特定硬件性能事件。
+#[derive(Debug, Clone, Copy)]
+pub enum PerfEvent {
+    /// Counts the number of CPU cycles. / 统计 CPU 周期数。
+    Cycles,
+    /// Counts the number of instructions executed. / 统计执行的指令数。
+    Instructions,
+}
+
+impl PerfEvent {
+    /// Converts the enum variant into the raw `type` and `config` values required by `perf_event_attr`.
+    ///
+    /// 将枚举变体转换为 `perf_event_attr` 所需的原始 `type` 和 `config` 值。
+    fn to_config(self) -> (u32, u64) {
+        match self {
+            Self::Cycles => {
+                (sys::bindings::PERF_TYPE_HARDWARE, sys::bindings::PERF_COUNT_HW_CPU_CYCLES as u64)
+            }
+            Self::Instructions => (
+                sys::bindings::PERF_TYPE_HARDWARE,
+                sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64,
+            ),
+        }
+    }
+}
+
+/// A handle to a group of performance counters, ensuring they are closed on drop.
+/// This struct manages the lifecycle of the file descriptors returned by `perf_event_open`.
+///
+/// 性能计数器组的句柄，确保在销毁时关闭它们。
+/// 此结构体管理 `perf_event_open` 返回的文件描述符的生命周期。
+#[derive(Debug)]
+pub struct EventGroup {
+    fds: Vec<RawFd>,
+}
+
+impl EventGroup {
+    /// Returns the file descriptor of the group leader.
+    /// This is the primary FD used for group-wide operations like `ioctl`.
+    ///
+    /// 返回组长的文件描述符。
+    /// 这是用于组范围操作（如 `ioctl`）的主要文件描述符。
+    pub fn leader_fd(&self) -> RawFd {
+        // The first FD in our list is always the leader.
+        // The constructor ensures the list is never empty.
+        self.fds[0]
+    }
+}
+
+impl Drop for EventGroup {
+    /// Closes all file descriptors associated with this event group.
+    ///
+    /// 关闭与此事件组关联的所有文件描述符。
+    fn drop(&mut self) {
+        for &fd in &self.fds {
+            // This is an unsafe call to a C function, but it's safe in this context
+            // as we own the file descriptors and they are valid until `drop` is called.
+            // 这是一个对 C 函数的非安全调用，但在这种上下文中是安全的，
+            // 因为我们拥有文件描述符，并且它们在 `drop` 被调用前都是有效的。
+            unsafe {
+                libc::close(fd);
+            }
+        }
+    }
+}
+
+/// Creates a group of performance counters that can be inherited by child processes.
+/// The group is created in a disabled state.
+///
+/// 创建一个可由子进程继承的性能计数器组。
+/// 该组在创建时处于禁用状态。
+///
+/// # Arguments
+/// * `events`: A slice of `PerfEvent`s to monitor. The first event becomes the group leader.
+///
+/// # Returns
+/// An `EventGroup` handle on success, which manages the file descriptors.
+pub fn create_event_group(events: &[PerfEvent]) -> Result<EventGroup, PipaCollectorError> {
+    if events.is_empty() {
+        return Err(PipaCollectorError::InvalidFormat(
+            "Cannot create an event group with no events.".to_string(),
+        ));
+    }
+
+    let mut fds = Vec::with_capacity(events.len());
+    let mut leader_fd: RawFd = -1;
+
+    for (i, event) in events.iter().enumerate() {
+        let (type_, config) = event.to_config();
+
+        let mut attrs = sys::bindings::perf_event_attr {
+            type_,
+            config,
+            size: std::mem::size_of::<sys::bindings::perf_event_attr>() as u32,
+            ..Default::default()
+        };
+
+        // --- Critical Settings for Child Process Monitoring ---
+        if i == 0 {
+            attrs.set_disabled(1);
+            attrs.set_inherit(1);
+        }
+
+        // The syscall is unsafe because it's a raw FFI call.
+        // We must ensure the arguments are valid.
+        // `pid = 0`: Monitor the current process's children (when they exec).
+        // `cpu = -1`: Monitor on all CPUs.
+        // `group_fd`: The FD of the group leader, or -1 if this *is* the leader.
+        // `flags = 0`: No special flags needed.
+        let fd = unsafe { sys::perf_event_open(&mut attrs, 0, -1, leader_fd, 0) };
+
+        if fd < 0 {
+            // On error, `perf_event_open` returns a negative value.
+            // We capture the OS error (from `errno`) and return it.
+            return Err(PipaCollectorError::Io(io::Error::last_os_error()));
+        }
+
+        if i == 0 {
+            leader_fd = fd;
+        }
+        fds.push(fd);
+    }
+
+    Ok(EventGroup { fds })
+}

--- a/crates/pipa_collector/src/raw_perf_events.rs
+++ b/crates/pipa_collector/src/raw_perf_events.rs
@@ -131,6 +131,8 @@ pub fn create_event_group(events: &[PerfEvent]) -> Result<EventGroup, PipaCollec
         if i == 0 {
             attrs.set_disabled(1);
             attrs.set_inherit(1);
+            attrs.read_format =
+                (sys::bindings::PERF_FORMAT_GROUP | sys::bindings::PERF_FORMAT_ID) as u64;
         }
 
         // The syscall is unsafe because it's a raw FFI call.

--- a/crates/pipa_collector/src/raw_perf_events.rs
+++ b/crates/pipa_collector/src/raw_perf_events.rs
@@ -1,0 +1,26 @@
+// Copyright 2025 cagedbird043
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides a low-level, unsafe interface to the `perf_event_open` syscall.
+//! It is designed to be the single point of contact with raw `perf_event_open` calls,
+//! isolating all `unsafe` logic related to this functionality. The primary motivation
+//! for using this raw interface is to gain access to features not exposed by safe
+//! high-level libraries, such as creating inheritable performance counter groups
+//! for monitoring child processes.
+//!
+//! 本模块提供了对 `perf_event_open` 系统调用的底层、非安全接口。
+//! 它被设计为与原始 `perf_event_open` 调用的唯一接触点，隔离了所有与此功能相关的 `unsafe` 逻辑。
+//! 使用此原始接口的主要动机是访问安全的高级库未暴露的功能，例如为监控子进程创建可继承的性能计数器组。
+
+// TODO: Implement wrapper functions around the syscall.


### PR DESCRIPTION
### Description

This PR introduces the `stat` subcommand, providing a native, unprivileged replacement for `perf stat` in PIPA-rs. This marks the completion of a critical task in our initial milestone, enabling the core functionality of monitoring a child process's performance counters.

The development of this feature involved a significant deep dive into the `perf_event_open` syscall's behavior. Initial approaches assuming the necessity of "event groups" and manual `ioctl` calls led to a challenging debugging process involving multiple `EINVAL`, `ENOSPC`, and `EPERM` errors.

The breakthrough came from using `strace` to analyze the behavior of the native `perf` tool itself. This revealed a much simpler and more robust implementation strategy:

1.  **No Event Groups**: For the `stat` use case, `perf` creates multiple **independent** counters.
2.  **`enable_on_exec` is Key**: Instead of complex `ioctl` hooks, `perf` uses the `enable_on_exec` flag, which instructs the kernel to automatically enable the counters at the moment the child process executes its new program image.

This PR refactors the entire implementation to precisely mimic this proven, correct behavior. The result is a `stat` command that works reliably out-of-the-box without requiring any special system configurations, capabilities, or user privileges, perfectly aligning with our project's core philosophy.

### Key Changes

*   **`pipa_collector`**: The `raw_perf_events` module was completely refactored. It now provides a `create_counter_for_command` function that correctly configures a single, inheritable, `enable_on_exec` counter. The incorrect "event group" logic has been removed.
*   **`pipa_cli`**: The `run_stat` function has been rewritten to be much simpler. It now creates two independent counters and reads from them separately after the child process exits. The complex and error-prone `pre_exec` hook has been eliminated.
*   **`tests`**: A new integration test suite, `tests/stat.rs`, has been added. It uses the `assert_cmd` and `predicates` crates to perform black-box testing of the compiled `pipa-rs` binary, verifying its functionality, output, and error handling.
*   **`ROADMAP.md`**: The project roadmap has been updated to mark Task 1.3 as complete, including a note about the technical decision to use raw syscalls over high-level crates.

### How Has This Been Tested?

The new functionality is validated by a suite of integration tests that:
- Execute the `pipa-rs stat` command on a successful program (`true`).
- Verify the presence of `Cycles`, `Instructions`, and `CPI` in the standard output.
- Assert correct failure and error messaging when given a non-existent command.
- Assert correct failure when no command is provided.

All tests pass successfully in a standard, unprivileged user environment.

### Related Issues/Tasks

- Completes: **Milestone 1, Task 1.3** in `ROADMAP.md`.